### PR TITLE
feat:OSS驱动获取文件URL

### DIFF
--- a/src/Oss/OssAdapter.php
+++ b/src/Oss/OssAdapter.php
@@ -508,4 +508,22 @@ class OssAdapter extends  AbstractAdapter
         return true;
     }
 
+    /**
+     * 获取当前文件的URL访问路径
+     * @param  string $file 文件名
+     * @param  integer $expire_at 有效期，单位：秒
+     * @return string       
+     * @author qsnh <616896861@qq.com>
+     */
+    public function getUrl($file, $expire_at = 3600)
+    {
+        try {
+            $accessUrl = $this->getOss()->signUrl($this->bucket, $file, $expire_at);
+        } catch (OssException $e) {
+            return false;
+        }
+
+        return $accessUrl;
+    }
+
 }


### PR DESCRIPTION
项目中使用OSS驱动，但是无法获取OOS文件的URL，所以增加了一个方法。 @tyua07 
`\Storage::disk('oss')->url('file.png');`